### PR TITLE
Migrate GPIO construction for SDK 2.0.0-alpha.196

### DIFF
--- a/examples/i2c.toit
+++ b/examples/i2c.toit
@@ -2,13 +2,12 @@
 // Use of this source code is governed by a MIT-style license that can be found
 // in the LICENSE file.
 
-import gpio
 import i2c
 
 import ublox_gnss
 
-SDA ::= gpio.Pin 21
-SCL ::= gpio.Pin 22
+SDA ::= 21
+SCL ::= 22
 
 main:
   bus := i2c.Bus --sda=SDA --scl=SCL

--- a/examples/serial.toit
+++ b/examples/serial.toit
@@ -2,15 +2,14 @@
 // Use of this source code is governed by a MIT-style license that can be found
 // in the LICENSE file.
 
-import gpio
 import i2c
 import uart
 import io
 
 import ublox-gnss
 
-TX-PIN := gpio.Pin 17
-RX-PIN := gpio.Pin 18
+TX-PIN := 17
+RX-PIN := 18
 BAUD   := 9600
 UART   := 0
 

--- a/package.yaml
+++ b/package.yaml
@@ -12,4 +12,4 @@ dependencies:
     version: ^2.2.0
 
 environment:
-  sdk: ^2.0.0-alpha.144
+  sdk: ^2.0.0-alpha.194.1

--- a/package.yaml
+++ b/package.yaml
@@ -12,4 +12,4 @@ dependencies:
     version: ^2.2.0
 
 environment:
-  sdk: ^2.0.0-alpha.194.1
+  sdk: ^2.0.0-alpha.196


### PR DESCRIPTION
## Summary

- update GPIO/peripheral construction for the SDK integer-pin API
- require Toit SDK `^2.0.0-alpha.196`
- modernize the package publish workflow where needed

Part of the SDK 196 package migration.